### PR TITLE
Set up api deployment to use Java 17

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -20,12 +20,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: holocanon
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
       - name: Generate the API data
         run: chmod +x holocanon/gradlew && holocanon/gradlew -p holocanon :api:run
       - name: Move api to io
-        run:  rm -r holocanon-api && mv holocanon/api/holocanon-api holocanon-api
+        run: rm -r holocanon-api && mv holocanon/api/holocanon-api holocanon-api
       - name: check git status
-        run : git status
+        run: git status
       - name: Configure git
         run: git config --global user.name "Shawn Witte" && git config --global user.email "shawn.l.witte@gmail.com"
       - name: commit and push to the api repo


### PR DESCRIPTION
The latest API deployment attempt failed because it's trying to run with Java 17.  It also shouldn't have run at all, but I guess the addition of `SetLatestDatabaseVersion.kt` triggered it.