### PR TITLE
Tweak media card UI to reduce checkbox/scrollbar overlap

### DIFF
--- a/app/src/main/res/layout/media_list_item.xml
+++ b/app/src/main/res/layout/media_list_item.xml
@@ -1,97 +1,97 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
 
     <ImageView
-            android:id="@+id/image_cover"
-            android:layout_width="100dp"
-            android:layout_height="160dp"
-            android:layout_margin="8dp"
-            android:contentDescription="@string/cover_art"
-            android:scaleType="centerInside"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/media_title" />
+        android:id="@+id/image_cover"
+        android:layout_width="100dp"
+        android:layout_height="160dp"
+        android:layout_margin="8dp"
+        android:contentDescription="@string/cover_art"
+        android:scaleType="centerInside"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/media_title" />
 
     <TextView
-            android:id="@+id/media_title"
-            style="@style/ListItemTitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="8dp"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="An interesting title" />
+        android:id="@+id/media_title"
+        style="@style/ListItemTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="An interesting title" />
 
     <TextView
-            android:id="@+id/date_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="8dp"
-            app:layout_constraintLeft_toRightOf="@id/image_cover"
-            app:layout_constraintTop_toBottomOf="@id/media_title"
-            tools:text="04/25/1989" />
+        android:id="@+id/date_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        app:layout_constraintLeft_toRightOf="@id/image_cover"
+        app:layout_constraintTop_toBottomOf="@id/media_title"
+        tools:text="04/25/1989" />
 
     <TextView
-            android:id="@+id/media_type"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:text="@string/media_type"
-            app:layout_constraintLeft_toRightOf="@id/image_cover"
-            app:layout_constraintTop_toBottomOf="@id/date_textview" />
+        android:id="@+id/media_type"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/media_type"
+        app:layout_constraintLeft_toRightOf="@id/image_cover"
+        app:layout_constraintTop_toBottomOf="@id/date_textview" />
 
     <TextView
-            android:id="@+id/series"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintLeft_toLeftOf="@id/date_textview"
-            app:layout_constraintTop_toBottomOf="@id/date_textview" />
+        android:id="@+id/series"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintLeft_toLeftOf="@id/date_textview"
+        app:layout_constraintTop_toBottomOf="@id/date_textview" />
 
     <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:gravity="end"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/media_title">
+
+        <CheckBox
+            android:id="@+id/checkbox_1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="end"
-            android:orientation="vertical"
-        android:layout_marginEnd="16dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/media_title">
+            android:button="@null"
+            android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
+            android:focusable="false"
+            android:padding="@dimen/checkbox_padding"
+            tools:text="@string/checkbox1_default_text" />
 
         <CheckBox
-                android:id="@+id/checkbox_1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:button="@null"
-                android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
-                android:focusable="false"
-                android:padding="@dimen/checkbox_padding"
-                tools:text="@string/checkbox1_default_text" />
+            android:id="@+id/checkbox_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:button="@null"
+            android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
+            android:focusable="false"
+            android:padding="@dimen/checkbox_padding"
+            tools:text="@string/checkbox2_default_text" />
 
         <CheckBox
-                android:id="@+id/checkbox_2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:button="@null"
-                android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
-                android:focusable="false"
-                android:padding="@dimen/checkbox_padding"
-                tools:text="@string/checkbox2_default_text" />
-
-        <CheckBox
-                android:id="@+id/checkbox_3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:button="@null"
-                android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
-                android:focusable="false"
-                android:padding="@dimen/checkbox_padding"
-                tools:text="@string/checkbox3_default_text" />
+            android:id="@+id/checkbox_3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:button="@null"
+            android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
+            android:focusable="false"
+            android:padding="@dimen/checkbox_padding"
+            tools:text="@string/checkbox3_default_text" />
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/media_list_item.xml
+++ b/app/src/main/res/layout/media_list_item.xml
@@ -58,6 +58,7 @@
             android:layout_height="wrap_content"
             android:gravity="end"
             android:orientation="vertical"
+        android:layout_marginEnd="16dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@id/media_title">


### PR DESCRIPTION
Request from CoMiGa via the discord channel: "I keep accidentally scrolling when adding to my list, I think because the checks are so close to the scrollbar. I wonder if that behavior could be improved."

The added margin should hopefully be sufficient.