### PR TITLE
Fix database injection to be Singleton

### DIFF
--- a/core/src/androidMain/kotlin/com/minirogue/starwarscanontracker/core/di/RoomModule.kt
+++ b/core/src/androidMain/kotlin/com/minirogue/starwarscanontracker/core/di/RoomModule.kt
@@ -13,6 +13,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -22,6 +23,7 @@ internal interface RoomModule {
 
     companion object {
         @Provides
+        @Singleton
         fun provideDatabase(application: Application): MediaDatabase =
             MediaDatabase.getMediaDatabase(application)
 

--- a/core/src/androidMain/kotlin/com/minirogue/starwarscanontracker/core/di/RoomModule.kt
+++ b/core/src/androidMain/kotlin/com/minirogue/starwarscanontracker/core/di/RoomModule.kt
@@ -25,7 +25,7 @@ internal interface RoomModule {
         @Provides
         @Singleton
         fun provideDatabase(application: Application): MediaDatabase =
-            MediaDatabase.getMediaDatabase(application)
+            MediaDatabase.createDatabase(application)
 
         @Provides
         fun provideDaoMedia(database: MediaDatabase): DaoMedia {

--- a/core/src/androidMain/kotlin/com/minirogue/starwarscanontracker/core/model/room/MediaDatabase.kt
+++ b/core/src/androidMain/kotlin/com/minirogue/starwarscanontracker/core/model/room/MediaDatabase.kt
@@ -52,7 +52,6 @@ abstract class MediaDatabase : RoomDatabase() {
     }
 
     companion object {
-        private var databaseInstance: MediaDatabase? = null
         private const val DATABASE_NAME = "StarWars-database"
         private const val LATEST_PREPACKAGED_DATABASE = "schema16_ver13.db"
 
@@ -154,8 +153,7 @@ abstract class MediaDatabase : RoomDatabase() {
             }
         }
 
-        fun getMediaDatabase(context: Context): MediaDatabase =
-            databaseInstance ?: Room.databaseBuilder(
+        fun createDatabase(context: Context): MediaDatabase = Room.databaseBuilder(
                 context.getApplicationContext(),
                 MediaDatabase::class.java,
                 DATABASE_NAME


### PR DESCRIPTION
There was an issue where `Flow` coming from the Room database wouldn't be getting updated (but the database was confirmed to be updated by closing and re-opening the app). At some point (potentially commit 19a0a617), the Room database stopped being a true singleton, which was handled by keeping a static variable in the Java class and now in the Kotlin `companion object`. It's a bit safer to let Dagger handle the Singleton-ness.