### PR TITLE
Turn flows into hot flows to speed up media list query

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,6 +20,7 @@ kotlin.sourceSets.androidMain.dependencies {
     implementation libs.androidx.lifecycle.viewmodel
     implementation projects.library.commonModels.public
     implementation projects.library.settings.public
+    implementation projects.library.coroutineExt.public
 }
 
 kotlin.sourceSets.androidInstrumentedTest.dependencies {

--- a/core/src/androidMain/kotlin/com/minirogue/starwarscanontracker/core/usecase/AdaptMediaItemDtoToStarWarsMedia.kt
+++ b/core/src/androidMain/kotlin/com/minirogue/starwarscanontracker/core/usecase/AdaptMediaItemDtoToStarWarsMedia.kt
@@ -1,6 +1,7 @@
 package com.minirogue.starwarscanontracker.core.usecase
 
 import android.util.Log
+import com.holocanon.library.coroutine.ext.HolocanonDispatchers
 import com.minirogue.common.model.Company
 import com.minirogue.common.model.MediaType
 import com.minirogue.common.model.StarWarsMedia
@@ -8,9 +9,13 @@ import com.minirogue.starwarscanontracker.core.model.room.dao.DaoCompany
 import com.minirogue.starwarscanontracker.core.model.room.dao.DaoSeries
 import com.minirogue.starwarscanontracker.core.model.room.entity.MediaItemDto
 import dagger.Reusable
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
@@ -19,20 +24,25 @@ class AdaptMediaItemDtoToStarWarsMedia @Inject internal constructor(
     private val daoCompany: DaoCompany,
     private val daoSeries: DaoSeries,
     private val json: Json,
+    private val dispatchers: HolocanonDispatchers,
 ) {
-    private var companyMap: Flow<Map<Int, Company>> = daoCompany.getAllCompanies()
+    private val adapterScope = CoroutineScope(Job() + dispatchers.default)
+    private val companyMap: SharedFlow<Map<Int, Company>> = daoCompany.getAllCompanies()
         .map { list ->
             list.associate {
                 it.id to json.decodeFromString<Company>("\"${it.companyName}\"")
             }
         }
-    private var seriesMap: Flow<Map<Int, String>> = daoSeries.getAllSeries()
+        .shareIn(scope = adapterScope, started = SharingStarted.Lazily, replay = 1)
+
+    private val seriesMap: SharedFlow<Map<Int, String>> = daoSeries.getAllSeries()
         .map { list -> list.associate { it.id to it.title } }
+        .shareIn(scope = adapterScope, started = SharingStarted.Lazily, replay = 1)
 
     suspend operator fun invoke(mediaItemDto: MediaItemDto): StarWarsMedia = StarWarsMedia(
         id = mediaItemDto.id.toLong(),
         title = mediaItemDto.title,
-        type = MediaType.getFromLegacyId(mediaItemDto.type) ?: MediaType.REFERENCE,
+        type = MediaType.getFromLegacyId(mediaItemDto.type),
         imageUrl = mediaItemDto.imageURL,
         releaseDate = mediaItemDto.date,
         timeline = mediaItemDto.timeline.toFloat(),


### PR DESCRIPTION
There was an issue where the adapter that mapped the media DTO objects to the domain object would reference flows for the Series and Company data. These flows would be recreated and re-run for every single adapter call, but converting them to shared flows causes them to only be created once (and they should still update when the database reports a change)